### PR TITLE
Update exception.py add space before error message

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -111,7 +111,7 @@ class TensorsNotCollocatedException(Exception):
                 "You tried to call "
                 + attr
                 + " involving two tensors where one tensor is actually located"
-                + "on another machine (is a PointerTensor). Call .get() on the PointerTensor or .send("
+                + " on another machine (is a PointerTensor). Call .get() on the PointerTensor or .send("
                 + str(tensor_b.location.id)
                 + ") on the other tensor.\n"
                 + "\nTensor A: "


### PR DESCRIPTION
Add a space after open quote, before error message so displays nicely
"on another machine (is a PointerTensor). Call .get() on the PointerTensor or .send("
error message change " involving two tensors where one tensor is actually `locatedon` -->> `located on` another machine (is a PointerTensor). Call .get() on the PointerTensor or .send("